### PR TITLE
[CRONAPP-1941] Projeto sem backend não roda

### DIFF
--- a/project/M/cronapp-rad-project-mobile-cordova/src/main/mobileapp/www/www-sem-autenticacao/__linksInherit
+++ b/project/M/cronapp-rad-project-mobile-cordova/src/main/mobileapp/www/www-sem-autenticacao/__linksInherit
@@ -1,11 +1,7 @@
-../../project/M/cronapp-rad-project-mobile-cordova/src/main/mobileapp/www/www-autenticacao/bowerscripts
 ../../project/M/cronapp-rad-project-mobile-cordova/src/main/mobileapp/www/www-autenticacao/css
 ../../project/M/cronapp-rad-project-mobile-cordova/src/main/mobileapp/www/www-autenticacao/i18n
 ../../project/M/cronapp-rad-project-mobile-cordova/src/main/mobileapp/www/www-autenticacao/img
 ../../project/M/cronapp-rad-project-mobile-cordova/src/main/mobileapp/www/www-autenticacao/js
-../../project/M/cronapp-rad-project-mobile-cordova/src/main/mobileapp/www/www-autenticacao/plugins
-../../project/M/cronapp-rad-project-mobile-cordova/src/main/mobileapp/www/www-autenticacao/.bowerrc
-../../project/M/cronapp-rad-project-mobile-cordova/src/main/mobileapp/www/www-autenticacao/bower.json
 ../../project/M/cronapp-rad-project-mobile-cordova/src/main/mobileapp/www/www-autenticacao/favicon.ico
 ../../project/M/cronapp-rad-project-mobile-cordova/src/main/mobileapp/www/www-autenticacao/cordova.js
 ../../project/M/cronapp-rad-project-mobile-cordova/src/main/mobileapp/www/www-autenticacao/cordova_plugins.js

--- a/project/W/cronapp-rad-project/src/main/webapp-sem-autenticacao/webapp/__linksInherit
+++ b/project/W/cronapp-rad-project/src/main/webapp-sem-autenticacao/webapp/__linksInherit
@@ -1,7 +1,3 @@
-../../project/W/cronapp-rad-project/src/main/webapp-autenticacao/webapp/bowerscripts
 ../../project/W/cronapp-rad-project/src/main/webapp-autenticacao/webapp/i18n
 ../../project/W/cronapp-rad-project/src/main/webapp-autenticacao/webapp/js
 ../../project/W/cronapp-rad-project/src/main/webapp-autenticacao/webapp/css
-../../project/W/cronapp-rad-project/src/main/webapp-autenticacao/webapp/plugins
-../../project/W/cronapp-rad-project/src/main/webapp-autenticacao/webapp/.bowerrc
-../../project/W/cronapp-rad-project/src/main/webapp-autenticacao/webapp/bower.json


### PR DESCRIPTION
Removidas referencias obsoletas de arquivos antigos, a ide ficava tentando mover e ocasionava em erros ao abrir o projeto