### PR TITLE
CRONAPP-2496  Opção de linkar certificado não aparece ao criar projeto com autenticação mútua

### DIFF
--- a/project/W/cronapp-rad-project/src/main/webapp-autenticacao/webapp/views/logged/home.view.html.ftl
+++ b/project/W/cronapp-rad-project/src/main/webapp-autenticacao/webapp/views/logged/home.view.html.ftl
@@ -40,6 +40,9 @@
                     </a>
                     <ul class="dropdown-menu">
                         <li><a href="" class="component-holder" ng-click="cronapi.screen.showModal('modalPassword')" data-component="crn-anchor">{{"Home.view.ChangePassword" | translate}}</a></li>
+                        <#if mutual?? && mutual?lower_case == "sim" && (enterprise)!false>
+                        <li><a ng-click="cronapi.client('js.blockly.MutualAuth.signup').run()" href="" data-component="crn-anchor"><span>{{'LinkCertificate' | translate}}</span></a></li>
+                        </#if>                        
                         <li><a ng-click="logout()" href="" data-component="crn-anchor"><span>{{"Home.view.Logout" | translate}}</span></a></li>
                     </ul>
                 </li>


### PR DESCRIPTION
**Problema**

A opção de linkar o certificado ao usuário não aparece.

**Solução**

A opção tinha sido excluída por engano e foi adicionada novamente.