### PR TITLE
CRONAPP-2538  Erro ao executar projeto localmente via Docker

### DIFF
--- a/project/W/cronapp-rad-project/Dockerfile
+++ b/project/W/cronapp-rad-project/Dockerfile
@@ -4,11 +4,13 @@ WORKDIR /app
 
 ADD pom.xml .
 
-RUN mvn dependency:go-offline -B
+RUN mvn dependency:resolve
 
 ADD . .
 
-RUN mvn package
+ADD . .
+
+RUN mvn clean package
 
 FROM tomcat:9.0.17-jre11
 

--- a/project/W/cronapp-rad-project/Dockerfile
+++ b/project/W/cronapp-rad-project/Dockerfile
@@ -1,12 +1,12 @@
-FROM maven:3.5-jdk-8 as maven_builder
+FROM maven:3.5-jdk-11 as maven_builder
 
 WORKDIR /app
 
-ADD ../pom.xml .
+ADD pom.xml .
 
 RUN mvn dependency:go-offline -B
 
-ADD .. .
+ADD . .
 
 RUN mvn package
 


### PR DESCRIPTION
**Problema**

Os caminhos estão relativos à pasta pai, causando erros na Build

**Solução**
Ajustar os caminhos para serem relativos à pasta atual