### PR TITLE
CRONAPP-2543 Campo Nome da chave estrangeira não altera o valor do co…

### DIFF
--- a/templates/low-code/data-layer/ENTITIES.ftl
+++ b/templates/low-code/data-layer/ENTITIES.ftl
@@ -173,7 +173,7 @@ public class ${clazz.name} implements Serializable {
         <#if (field.relationNames?size == 1)>
             <#list field.relationNames?keys as key>
                 <#if key??>
-    @JoinColumn(name="${key}", nullable = ${field.nullable?c}, referencedColumnName = "${field.relationNames[key]}", insertable=${field.insertable?c}, updatable=${field.updatable?c}<#if field.cascade>, foreignKey = @ForeignKey(name = "<#if tableName??>${tableName}<#else>${clazz.name?upper_case}</#if>_${key?upper_case}_${field.dbTableRelationClazz}_${field.relationNames[key]?upper_case}", foreignKeyDefinition = "FOREIGN KEY (${key}) REFERENCES ${field.dbTableRelationClazz} (${field.relationNames[key]}) ON DELETE CASCADE")<#elseif field.fkName??>, foreignKey = @ForeignKey(name = "${field.fkName}")</#if>)
+    @JoinColumn(name="${key}", nullable = ${field.nullable?c}, referencedColumnName = "${field.relationNames[key]}", insertable=${field.insertable?c}, updatable=${field.updatable?c}<#if field.cascade>, foreignKey = @ForeignKey(name = "<#if tableName??>${tableName}<#else>${clazz.name?upper_case}</#if>_${key?upper_case}_${field.dbTableRelationClazz}_${field.relationNames[key]?upper_case}", foreignKeyDefinition = "FOREIGN KEY (${key}) REFERENCES ${field.dbTableRelationClazz} (${field.relationNames[key]}) ON DELETE CASCADE")<#elseif field.fkName??>, foreignKey = @ForeignKey(name = "${field.fkName}", foreignKeyDefinition = "FOREIGN KEY (${key}) REFERENCES ${field.dbTableRelationClazz} (${field.relationNames[key]})")</#if>)
                 </#if>
             </#list>
         <#elseif (field.relationNames?size > 1)>
@@ -181,7 +181,7 @@ public class ${clazz.name} implements Serializable {
     @JoinColumns({
             <#list field.relationNames?keys as key>
                 <#if key??>
-    @JoinColumn(name="${key}", nullable = ${field.nullable?c}, referencedColumnName = "${field.relationNames[key]}", insertable=${field.insertable?c}, updatable=${field.updatable?c}<#if field.fkName??>, foreignKey = @ForeignKey(name = "${field.fkName}")</#if>)
+    @JoinColumn(name="${key}", nullable = ${field.nullable?c}, referencedColumnName = "${field.relationNames[key]}", insertable=${field.insertable?c}, updatable=${field.updatable?c}<#if field.fkName??>, foreignKey = @ForeignKey(name = "${field.fkName}", foreignKeyDefinition = "FOREIGN KEY (${key}) REFERENCES ${field.dbTableRelationClazz} (${field.relationNames[key]})")</#if>)
                     <#if (i>1)>,</#if>
                 </#if>
                 <#assign i = i-1>


### PR DESCRIPTION
**Problema:**
Campo Nome da chave estrangeira não altera o valor do constraint da fk no banco
**Solução:**
É necessário adicionar o foreignKeyDefinition, pois a partir do momento que se utiliza a anotação @foreignKey, o eclipselink passa a ignorar as outras anotações de referencedColumnName