### PR TITLE
CRONAPP-2659 Ao exportar para git, está indo a pasta node_modules (we…

### DIFF
--- a/project/M/cronapp-rad-project-mobile-cordova/.gitignore
+++ b/project/M/cronapp-rad-project-mobile-cordova/.gitignore
@@ -24,4 +24,4 @@ buildNumber.properties
 build.properties
 ports.pid
 .replacement/**
-node_modules/**
+**/node_modules/**

--- a/project/W/cronapp-rad-project/.gitignore
+++ b/project/W/cronapp-rad-project/.gitignore
@@ -23,4 +23,4 @@ buildNumber.properties
 build.properties
 ports.pid
 .replacement/**
-node_modules/**
+**/node_modules/**


### PR DESCRIPTION
**Problema:**
Ao exportar para git, está indo a pasta node_modules (web e mobile)

**Solução:**
Ajustar a instrução node_modules dentro do arquivo .gitignore 