### PR TITLE
CRONAPP-2675  Gerar jar de um sistema criado com o Cronapp e rodar

### DIFF
--- a/project/W/cronapp-rad-project/pom.xml.ftl
+++ b/project/W/cronapp-rad-project/pom.xml.ftl
@@ -70,6 +70,11 @@
                     </execution>
                 </executions>
             </plugin>
+            <plugin>
+                <groupId>org.springframework.boot</groupId>
+                <artifactId>spring-boot-maven-plugin</artifactId>
+                <version>2.0.1.RELEASE</version>
+            </plugin>
         </plugins>
     </build>
     <repositories>


### PR DESCRIPTION
**Problema**

O war gerado pelo cronapp não executa como jar

**Solução**

Adicionar o plugin maven no template