### PR TITLE
CRONAPP-2766  Agendador de tarefas não usa as transações do Framework

### DIFF
--- a/templates/low-code/data-layer/Job.java.ftl
+++ b/templates/low-code/data-layer/Job.java.ftl
@@ -3,6 +3,7 @@
  */
 package app.jobs;
 
+import cronapi.database.TransactionManager;
 import cronapp.framework.scheduler.SchedulerConfigurer;
 import org.quartz.*;
 import org.springframework.beans.factory.annotation.Qualifier;
@@ -29,8 +30,13 @@ public class ${task.class} implements Job {
       //${action.name}
       ${action.code}
 </#list>
+      TransactionManager.commit();
     } catch (Exception e) {
+      TransactionManager.rollback();
       throw new JobExecutionException(e);
+    } finally {
+      TransactionManager.close();
+      TransactionManager.clear();
     }
   }
 


### PR DESCRIPTION
**Problema**
Os blocos utilizados no agendador de tarefas não estão com as transações gerenciadas

**Solução**
Adicionar o TransactionManager no código gerado