### PR TITLE
CRONAPP-2608 Gerar jar de um sistema criado com o Cronapp e rodar

### DIFF
--- a/project/W/cronapp-rad-project/pom.xml.ftl
+++ b/project/W/cronapp-rad-project/pom.xml.ftl
@@ -189,6 +189,11 @@
             <artifactId>cronapi-apm</artifactId>
             <version>1.0.0</version>
         </dependency>
+        <plugin>
+          <groupId>org.springframework.boot</groupId>
+          <artifactId>spring-boot-maven-plugin</artifactId>
+          <version>2.0.1.RELEASE</version>
+        </plugin>
     </dependencies>
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/project/W/cronapp-rad-project/pom.xml.ftl
+++ b/project/W/cronapp-rad-project/pom.xml.ftl
@@ -70,6 +70,11 @@
                     </execution>
                 </executions>
             </plugin>
+            <plugin>
+                <groupId>org.springframework.boot</groupId>
+                <artifactId>spring-boot-maven-plugin</artifactId>
+                <version>2.0.1.RELEASE</version>
+            </plugin>
         </plugins>
     </build>
     <repositories>

--- a/project/W/cronapp-rad-project/src/main/java/SpringBootMain.java.ftl
+++ b/project/W/cronapp-rad-project/src/main/java/SpringBootMain.java.ftl
@@ -1,4 +1,3 @@
-import cronapp.framework.boot.CronappInitializer;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
@@ -7,7 +6,7 @@ import org.springframework.boot.autoconfigure.orm.jpa.HibernateJpaAutoConfigurat
 import org.springframework.context.annotation.ComponentScan;
 
 import java.util.TimeZone;
-import org.springframework.boot.web.servlet.support.SpringBootServletInitializer;
+import cronapp.framework.boot.CronappInitializer;
 
 @SpringBootApplication
 @ComponentScan(basePackages = {
@@ -38,7 +37,7 @@ public class SpringBootMain extends CronappInitializer {
         </#if>
     }
 
-	public static void main(String[] args) throws Exception {
+	public static void main(String[] args) {
 		SpringApplication.run(SpringBootMain.class, args);
 	}
 

--- a/project/W/cronapp-rad-project/src/main/java/SpringBootMain.java.ftl
+++ b/project/W/cronapp-rad-project/src/main/java/SpringBootMain.java.ftl
@@ -1,3 +1,4 @@
+import cronapp.framework.boot.CronappInitializer;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
@@ -17,17 +18,17 @@ import org.springframework.boot.web.servlet.support.SpringBootServletInitializer
 	<#if mutual?? && mutual?lower_case == "sim" && (enterprise)!false>
 	"cronapp.framework.authentication.mutual",
 	</#if>
-    "cronapp.framework.scheduler",
+  "cronapp.framework.scheduler",
 	"auth.permission",
 	"api.rest.events",
 	"api.rest.webservices",
 	"reports",
 	"cronapi",
 	"blockly",
-"app"
+  "app"
 })
 @EnableAutoConfiguration(exclude = { DataSourceAutoConfiguration.class, HibernateJpaAutoConfiguration.class })
-public class SpringBootMain extends SpringBootServletInitializer {
+public class SpringBootMain extends CronappInitializer {
 
     static {
     	<#if timezone?? && timezone?lower_case != "utc">
@@ -38,7 +39,7 @@ public class SpringBootMain extends SpringBootServletInitializer {
     }
 
 	public static void main(String[] args) throws Exception {
-		CronappApplication.run(args);
+		SpringApplication.run(SpringBootMain.class, args);
 	}
 
 }

--- a/project/W/cronapp-rad-project/src/main/java/app/AppConfiguration.java.ftl
+++ b/project/W/cronapp-rad-project/src/main/java/app/AppConfiguration.java.ftl
@@ -8,8 +8,10 @@ import org.springframework.transaction.annotation.*;
 <#if (!authentication??) || (authentication?lower_case) == "normal" || (authentication?lower_case) == "token" || (authentication?lower_case) == "sso" || authentication?lower_case == "saml">
 import org.springframework.core.io.*;
 import org.springframework.data.repository.init.*;
+
 import java.net.URL;
-import java.io.File;
+import java.io.IOException;
+import java.io.InputStream;
 import java.util.Scanner;
 import java.util.regex.Pattern;
 </#if>
@@ -38,26 +40,23 @@ public class AppConfiguration {
 <#if (!authentication??) || (authentication?lower_case) == "normal" || (authentication?lower_case) == "token" || (authentication?lower_case) == "sso" || authentication?lower_case == "saml" >
   @Bean
   public Jackson2RepositoryPopulatorFactoryBean repositoryPopulator() {
-
     Jackson2RepositoryPopulatorFactoryBean factory = new Jackson2RepositoryPopulatorFactoryBean();
-    URL url = this.getClass().getClassLoader().getResource("app//populate.json");
+    URL url = this.getClass().getClassLoader().getResource("app/populate.json");
 
     String strJSON = "[]";
     if (url != null) {
-      File file = new File(url.getFile());
-
-      try {
-        Scanner scanner = new Scanner(file);
+      try (InputStream resourceInputStream = url.openStream()) {
+        Scanner scanner = new Scanner(resourceInputStream);
         strJSON = scanner.useDelimiter("\\A").next();
         scanner.close();
-
+        
         strJSON = strJSON.replaceAll(Pattern.quote("{{ROLE_ADMIN_NAME}}"), "Administrators");
-      } catch (Exception e) {
+      } catch (IOException e) {
       }
     }
 
     Resource sourceData = new InputStreamResource(new java.io.ByteArrayInputStream(strJSON.getBytes()));
-    factory.setResources(new Resource[] { sourceData });
+    factory.setResources(new Resource[]{sourceData});
 
     return factory;
 

--- a/templates/low-code/data-layer/SpringBootMain.java.ftl
+++ b/templates/low-code/data-layer/SpringBootMain.java.ftl
@@ -1,4 +1,3 @@
-import cronapp.framework.boot.CronappInitializer;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
@@ -7,7 +6,7 @@ import org.springframework.boot.autoconfigure.orm.jpa.HibernateJpaAutoConfigurat
 import org.springframework.context.annotation.ComponentScan;
 
 import java.util.TimeZone;
-import org.springframework.boot.web.servlet.support.SpringBootServletInitializer;
+import cronapp.framework.boot.CronappInitializer;
 
 @SpringBootApplication
 @ComponentScan(basePackages = {
@@ -38,7 +37,7 @@ public class SpringBootMain extends CronappInitializer {
         </#if>
     }
 
-	public static void main(String[] args) throws Exception {
+	public static void main(String[] args) {
 		SpringApplication.run(SpringBootMain.class, args);
 	}
 

--- a/templates/low-code/data-layer/SpringBootMain.java.ftl
+++ b/templates/low-code/data-layer/SpringBootMain.java.ftl
@@ -1,3 +1,4 @@
+import cronapp.framework.boot.CronappInitializer;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
@@ -17,7 +18,7 @@ import org.springframework.boot.web.servlet.support.SpringBootServletInitializer
 	<#if mutual?? && mutual?lower_case == "sim" && (enterprise)!false>
 	"cronapp.framework.authentication.mutual",
 	</#if>
-    "cronapp.framework.scheduler",
+  "cronapp.framework.scheduler",
 	"auth.permission",
 	"api.rest.events",
 	"api.rest.webservices",
@@ -27,7 +28,7 @@ import org.springframework.boot.web.servlet.support.SpringBootServletInitializer
 <#list workspaceView.allDiagrams as diagram>${diagram.getGlobalAttribute("namespace")}<#if diagram?has_next>, </#if></#list><#list packages as package>${package}<#if package?has_next>, </#if></#list>
 })
 @EnableAutoConfiguration(exclude = { DataSourceAutoConfiguration.class, HibernateJpaAutoConfiguration.class })
-public class SpringBootMain extends SpringBootServletInitializer {
+public class SpringBootMain extends CronappInitializer {
 
     static {
     	<#if timezone?? && timezone?lower_case != "utc">
@@ -38,7 +39,7 @@ public class SpringBootMain extends SpringBootServletInitializer {
     }
 
 	public static void main(String[] args) throws Exception {
-		CronappApplication.run(args);
+		SpringApplication.run(SpringBootMain.class, args);
 	}
 
 }


### PR DESCRIPTION
**Problema**
- As aplicações Cronapp não rodam como aplicação SpringBoot
- Ao rodar uma aplicação Cronapp como uma aplicação SpringBoot, o populate.json não é encontrado

**Solução**
- Utilizar o SpringApplication.run() para inicializar a aplicação
- Remover as "/" duplas do caminho do populate.json
- Utililizar URL.openStream() para abrir o populate.json, ele nem sempre estará em um sistema de arquivos