### PR TITLE
feature/CRONAPP-3455-hotfix-2.8.x

### DIFF
--- a/project/M/cronapp-rad-project-mobile-cordova/src/main/mobileapp/config.xml.ftl
+++ b/project/M/cronapp-rad-project-mobile-cordova/src/main/mobileapp/config.xml.ftl
@@ -108,5 +108,5 @@
 
 
     </platform>
-    <plugin name="cordova-plugin-cronapp" spec="https://github.com/cronapp/cordova-plugin-cronapp.git#develop"/>
+    <plugin name="cordova-plugin-cronapp" spec="~2.8.0"/>
 </widget>


### PR DESCRIPTION
CRONAPP-3455 - Falta de sincronismo com banco de dados local (local storage) após atualização de versão.

Solução
Do not use develop branch in 2.8.x branches