### PR TITLE
CRONAPP-3654 Projeto clonado do git não executa npm install

### DIFF
--- a/project/W/cronapp-rad-project/pom.xml.ftl
+++ b/project/W/cronapp-rad-project/pom.xml.ftl
@@ -75,6 +75,51 @@
                 <artifactId>spring-boot-maven-plugin</artifactId>
                 <version>2.0.1.RELEASE</version>
             </plugin>
+<#if (((frontend??) && (frontend?lower_case) == "true") || (androidSplashList?has_content))>
+            <plugin>
+                <groupId>org.codehaus.mojo</groupId>
+                <artifactId>exec-maven-plugin</artifactId>
+                <version>1.6.0</version>
+                <executions>
+<#if ((frontend??) && (frontend?lower_case) == "true")>
+                    <execution>
+                        <id>npm-install-web</id>
+                        <phase>generate-resources</phase>
+                        <goals>
+                            <goal>exec</goal>
+                        </goals>
+                        <configuration>
+                            <skip>false</skip>
+                            <executable>bash</executable>
+                            <arguments>
+                                <argument>-c</argument>
+                                <argument>npm install</argument>
+                            </arguments>
+                            <workingDirectory>src/main/webapp</workingDirectory>
+                        </configuration>
+                    </execution>
+</#if>
+<#if (androidSplashList?has_content)>
+                    <execution>
+                        <id>npm-install-mobile</id>
+                        <phase>generate-resources</phase>
+                        <goals>
+                            <goal>exec</goal>
+                        </goals>
+                        <configuration>
+                            <skip>false</skip>
+                            <executable>bash</executable>
+                            <arguments>
+                                <argument>-c</argument>
+                                <argument>npm install</argument>
+                            </arguments>
+                            <workingDirectory>src/main/mobileapp/www</workingDirectory>
+                        </configuration>
+                    </execution>
+</#if>
+                </executions>
+            </plugin>
+</#if>
         </plugins>
     </build>
     <repositories>
@@ -199,6 +244,7 @@
           <artifactId>spring-boot-maven-plugin</artifactId>
           <version>2.0.1.RELEASE</version>
         </plugin>
+
     </dependencies>
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>


### PR DESCRIPTION
Solução: Adicionado plugins para execução do npm install
Se for projeto apenas web sem frontend, nao adiciona o plugin
Se for projeto apenas web com frontend, adiciona o plugin com o npm apenas do web
Se for projeto mobile/web sem frontend, adiciona o plugin apenas com npm do mobile
Se for projeto mobile/web com frontend, adiciona o plugin com npm do web e do mobile