### PR TITLE
CRONAPP-3654 Projeto clonado do git não executa npm install

### DIFF
--- a/project/W/cronapp-rad-project/pom.xml.ftl
+++ b/project/W/cronapp-rad-project/pom.xml.ftl
@@ -75,7 +75,7 @@
                 <artifactId>spring-boot-maven-plugin</artifactId>
                 <version>2.0.1.RELEASE</version>
             </plugin>
-<#if (((frontend??) && (frontend?lower_case) == "true") || (androidSplashList?has_content))>
+<#if (((frontend??) && (frontend?lower_case) == "true") || (isMobileProject))>
             <plugin>
                 <groupId>org.codehaus.mojo</groupId>
                 <artifactId>exec-maven-plugin</artifactId>
@@ -99,7 +99,7 @@
                         </configuration>
                     </execution>
 </#if>
-<#if (androidSplashList?has_content)>
+<#if (isMobileProject)>
                     <execution>
                         <id>npm-install-mobile</id>
                         <phase>generate-resources</phase>


### PR DESCRIPTION
Adicionando nova variavel para verificar tipo de projeto, a antiga já funcionava corretamente em localhost para todos os branchs (2.8.x e develop), contorno problema de ambiente (develop)