### PR TITLE
CRONAPP-4513 - Plugin whitelist no template do config.xml

### DIFF
--- a/project/M/cronapp-rad-project-mobile-cordova/src/main/mobileapp/config.xml.ftl
+++ b/project/M/cronapp-rad-project-mobile-cordova/src/main/mobileapp/config.xml.ftl
@@ -4,7 +4,6 @@
     <description>${appname}</description>
     <author email="${useremail}" href="http://cronapp.io">${username}</author>
     <content src="index.html" />
-    <plugin name="cordova-plugin-whitelist" spec="1" />
     <access origin="*" />
     <allow-intent href="http://*/*" />
     <allow-intent href="https://*/*" />


### PR DESCRIPTION
Solução
Removido plugin que agora é depreciado na versão 10 do Android