### PR TITLE
CRONAPP-4451 Erro no bloco converter Bloco JSON para XML

### DIFF
--- a/project/W/cronapp-rad-project/pom.xml.ftl
+++ b/project/W/cronapp-rad-project/pom.xml.ftl
@@ -167,6 +167,12 @@
         <dependency>
             <groupId>io.cronapp</groupId>
             <artifactId>cronapp-framework-java</artifactId>
+	    <exclusions>
+                <exclusion>
+                  <groupId>com.google.code.gson</groupId>
+                    <artifactId>gson</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>io.cronapp</groupId>


### PR DESCRIPTION
**Problema**

A Exceção de método não encontrado é disparada eventualmente nos projetos devido a uma incompatibilidade de versões da biblioteca com.google.code.gson utilizada no projeto.

**Solução​** 

Incluir uma exclusão da biblioteca com.google.code.gson ao usar a dependência cronapp-framework-java