### PR TITLE
CRONAPP-4586 Vulnerabilidade CVE-2021-23424

### DIFF
--- a/project/N/nodejs-vuejs-project/package-lock.json
+++ b/project/N/nodejs-vuejs-project/package-lock.json
@@ -11861,7 +11861,7 @@
       "integrity": "sha512-fqPkuNalLuc/hRC2QMkVYJkgNmRvxZQo7ykA2e1XRg/tMJm3qY7ZaD6d89/Fqjxtj9bOrn5wZzLD2n84lJdvWg==",
       "dev": true,
       "requires": {
-        "ansi-html": "0.0.7",
+        "ansi-html-community": "^0.0.8",
         "bonjour": "^3.5.0",
         "chokidar": "^2.0.0",
         "compression": "^1.5.2",


### PR DESCRIPTION
**Problema**
Falha no ansi-html causando o CVE-2021-23424

**Solução**
Atualizar para ansi-html-community 0.0.8