### PR TITLE
CRONAPP-4502 Testes unitários não são executados

### DIFF
--- a/project/W/cronapp-rad-project/pom.xml.ftl
+++ b/project/W/cronapp-rad-project/pom.xml.ftl
@@ -146,11 +146,6 @@
             <version>1.1.2</version>
         </dependency>
         <dependency>
-            <groupId>org.seleniumhq.selenium</groupId>
-            <artifactId>selenium-java</artifactId>
-            <version>3.141.59</version>
-        </dependency>
-        <dependency>
             <groupId>io.cronapp</groupId>
             <artifactId>cronapi-java</artifactId>
             <exclusions>
@@ -188,6 +183,21 @@
             <groupId>io.cronapp</groupId>
             <artifactId>cronapi-apm</artifactId>
             <version>1.0.0</version>
+        </dependency>
+        <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-engine</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.vintage</groupId>
+            <artifactId>junit-vintage-engine</artifactId>
+            <scope>test</scope>
         </dependency>
     </dependencies>
     <repositories>


### PR DESCRIPTION
**Problema**
O Cronapp Framework 2.9.0 é baseado no JUnit 5. Os testes da IDE são baseados no JUnit 4

**Solução**
Adicionar bibliotecas que garantem a retro compatibilidade com os testes feitos utilizando o JUnit 4