### PR TITLE
CRONAPP-4987 - Opção de aceitar cookies não funciona

### DIFF
--- a/project/W/cronapp-rad-project/src/main/webapp-autenticacao/webapp/views/public/privacy/cookies.view.html
+++ b/project/W/cronapp-rad-project/src/main/webapp-autenticacao/webapp/views/public/privacy/cookies.view.html
@@ -10,7 +10,7 @@
             <a class="openconfigcookies" href="#" ng-click="cronapi.client('js.blockly.privacy.Cookies.openPreferences').names().run()">
                 {{'Privacy.view.Cookies.Dialog.OpenPreferences' | translate}}
             </a>
-            <button class="btn btn-success btn-sm acceptcookies" ng-click="cronapi.client('js.blockly.privacy.Cookies.setCookiesPreference').names().run()" xattr-fullsize="btn-block" xattr-theme="btn-success" xattr-disabled="">
+            <button class="btn btn-success btn-sm acceptcookies" ng-click="cronapi.client('js.blockly.privacy.Cookies.setPreference').names().run()" xattr-fullsize="btn-block" xattr-theme="btn-success" xattr-disabled="">
                 <i class="glyphicon glyphicon-ok"></i>
                 <span>{{'Privacy.view.Cookies.Accept' | translate}}</span>
             </button>


### PR DESCRIPTION
**Solução:**
Ajuste no nome da função no botão principal.