### PR TITLE
CRONAPP-5432 Templates não estão atualizados para versão correta

### DIFF
--- a/project/W/cronapp-rad-project/pom.xml.ftl
+++ b/project/W/cronapp-rad-project/pom.xml.ftl
@@ -3,7 +3,7 @@
     <parent>
         <groupId>io.cronapp</groupId>
         <artifactId>cronapp-framework-spring</artifactId>
-        <version>2.9.0-SNAPSHOT</version>
+        <version>2.9.1-SNAPSHOT</version>
         <relativePath />
     </parent>
     <modelVersion>4.0.0</modelVersion>


### PR DESCRIPTION
**PROBLEMA**
Ao criar novo projeto na IDE-A, o projeto é gerado com versão 2.9.0-SNAPSHOT, o que causa erro de compilação pois só a ultima versão SNAPSHOT é mantido no repositório maven.
**SOLUÇÃO**
Alterado a versão do parente, de 2.9.0-SNAPSHOT para 2.9.1-SNAPSHOT no arquivo project/W/cronapp-rad-project/pom.xml.ftl