### PR TITLE
CRONAPP-5212 - View mobile de reset de senha não carrega

### DIFF
--- a/project/M/cronapp-rad-project-mobile-cordova/src/main/mobileapp/www/www-autenticacao/views/login.view.html.ftl
+++ b/project/M/cronapp-rad-project-mobile-cordova/src/main/mobileapp/www/www-autenticacao/views/login.view.html.ftl
@@ -19,7 +19,7 @@
         </div>
 
         <div class="item">
-          <a href="" class="component-holder" style="display:block" xattr-fullsize="display:block;" data-replace="true" data-component="crn-anchor" id="reset-password-login" on-hold="" on-tap="$evt('cronapi.screen.changeView(\'#/app/public/reset-password-email\', [])')">{{'ResetPassword' | translate}}</a>
+          <a href="#/app/public/reset-password" class="component-holder" style="display:block" xattr-fullsize="display:block;" data-replace="true" data-component="crn-anchor" id="reset-password-login" on-hold="" on-tap="">{{'ResetPassword' | translate}}</a>
         </div>
 
         <div class="item" title="{{'Login.view.Login' | translate}}" for="crn-button-445347">


### PR DESCRIPTION
**Solução:**
Removido o evento de mudar formulário do on-tag (clique rápido) e passado para o href (tag <a>). 