### PR TITLE
CRONAPP-5252 Barra de aceitação de cookies não oculta

### DIFF
--- a/project/W/cronapp-rad-project/src/main/webapp-autenticacao/webapp/js/blockly/privacy/Cookies.blockly.js
+++ b/project/W/cronapp-rad-project/src/main/webapp-autenticacao/webapp/js/blockly/privacy/Cookies.blockly.js
@@ -41,6 +41,7 @@ window.blockly.js.blockly.privacy.Cookies.setPreference = async function() {
   this.cronapi.util.setCookie('cookieMarketing', isCheckedMarketingCookie, 'days', 365);
   this.cronapi.util.setCookie('cookieAnalytics', isCheckedAnalyticsCookie, 'days', 365);
   this.cronapi.util.setCookie('cookieEssencial', true, 'days', 365);
+  this.cronapi.screen.hideComponent("dialogCookies");
 }
 
 /**


### PR DESCRIPTION
**PROBLEMA**
Ao aceitar cookies, a barra não é escondida.
**SOLUÇÃO**
Alterado bloco para esconder a barra apos processar o aceite de cookies